### PR TITLE
Add vpc endpoints (#1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Telia Company
+Copyright (c) 2019 Vygruppen AS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a module which simplifies setting up a new VPC and getting it into a use
 - Creates a NAT gateway for your private subnets if desired (requires public subnets).
 - Creates an egress only internet gateway for IPv6 traffic outbound from the private subnets.
 - Adds the tag `type` to each subnet with the value of either `public` or `private`.
+- Adds VPC Gateway Endpoints for s3 and dynamodb
 
 Note that, if `create_nat_gateways` is enabled, each private subnet has a route table which targets an individual NAT gateway when accessing
 the internet over IPv4, which means that all instances in a given private subnet will appear to have the same static IP from the outside.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   version = ">= 2.17"
-  region  = "${var.region}"
+  region  = var.region
 }
 
 module "vpc" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   version = ">= 2.17"
-  region  = "${var.region}"
+  region  = var.region
 }
 
 module "vpc" {

--- a/examples/interface-endpoint/README.md
+++ b/examples/interface-endpoint/README.md
@@ -1,0 +1,8 @@
+## examples/interface-endpoint
+
+Adding an interface endpoint to a VPC for an AWS service eliminates the data transfer costs to use that service but 
+instead incurs a cost for adding ENIs in each subnet.  For this reason interface endpoints are not enabled by default.
+
+This example shows how to extend the VPC module to add interface endpoints.  It adds the interface endpoints
+necessary for using AWS Systems Manager / Session Manager to access an instances in a private subnet. The instances must 
+have the default vpc security group associated for this to work.

--- a/examples/interface-endpoint/main.tf
+++ b/examples/interface-endpoint/main.tf
@@ -1,0 +1,67 @@
+provider "aws" {
+  version = ">= 2.17"
+  region  = var.region
+}
+
+data "aws_availability_zones" "main" {}
+
+locals {
+  vpc_cidr_block = "10.100.0.0/16"
+  public_cidr_blocks = [for k, v in data.aws_availability_zones.main.names :
+  cidrsubnet(local.vpc_cidr_block, 4, k)]
+  private_cidr_blocks = [for k, v in data.aws_availability_zones.main.zone_ids :
+  cidrsubnet(local.vpc_cidr_block, 4, k + length(data.aws_availability_zones.main.names))]
+  tags = {
+    terraform   = "true"
+    environmemt = "dev"
+  }
+}
+
+module "vpc" {
+  source               = "../../"
+  name_prefix          = var.name_prefix
+  cidr_block           = local.vpc_cidr_block
+  availability_zones   = data.aws_availability_zones.main.names
+  private_subnet_cidrs = local.private_cidr_blocks
+  create_nat_gateways  = false
+  enable_dns_hostnames = true
+  tags                 = local.tags
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  service_name       = "com.amazonaws.${var.region}.ssm"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [module.vpc.default_security_group_id]
+  tags               = local.tags
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  service_name       = "com.amazonaws.${var.region}.ssmmessages"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [module.vpc.default_security_group_id]
+  tags               = local.tags
+  private_dns_enabled = true
+}
+resource "aws_vpc_endpoint" "ec2" {
+  service_name       = "com.amazonaws.${var.region}.ec2"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [module.vpc.default_security_group_id]
+  tags               = local.tags
+  private_dns_enabled = true
+}
+resource "aws_vpc_endpoint" "ec2messages" {
+  service_name       = "com.amazonaws.${var.region}.ec2messages"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [module.vpc.default_security_group_id]
+  tags               = local.tags
+  private_dns_enabled = true
+}

--- a/examples/interface-endpoint/main.tf
+++ b/examples/interface-endpoint/main.tf
@@ -29,39 +29,41 @@ module "vpc" {
 }
 
 resource "aws_vpc_endpoint" "ssm" {
-  service_name       = "com.amazonaws.${var.region}.ssm"
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
-  vpc_endpoint_type  = "Interface"
-  security_group_ids = [module.vpc.default_security_group_id]
-  tags               = local.tags
+  service_name        = "com.amazonaws.${var.region}.ssm"
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [module.vpc.default_security_group_id]
+  tags                = local.tags
   private_dns_enabled = true
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
-  service_name       = "com.amazonaws.${var.region}.ssmmessages"
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
-  vpc_endpoint_type  = "Interface"
-  security_group_ids = [module.vpc.default_security_group_id]
-  tags               = local.tags
+  service_name        = "com.amazonaws.${var.region}.ssmmessages"
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [module.vpc.default_security_group_id]
+  tags                = local.tags
   private_dns_enabled = true
 }
+
 resource "aws_vpc_endpoint" "ec2" {
-  service_name       = "com.amazonaws.${var.region}.ec2"
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
-  vpc_endpoint_type  = "Interface"
-  security_group_ids = [module.vpc.default_security_group_id]
-  tags               = local.tags
+  service_name        = "com.amazonaws.${var.region}.ec2"
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [module.vpc.default_security_group_id]
+  tags                = local.tags
   private_dns_enabled = true
 }
+
 resource "aws_vpc_endpoint" "ec2messages" {
-  service_name       = "com.amazonaws.${var.region}.ec2messages"
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
-  vpc_endpoint_type  = "Interface"
-  security_group_ids = [module.vpc.default_security_group_id]
-  tags               = local.tags
+  service_name        = "com.amazonaws.${var.region}.ec2messages"
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = compact(concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids))
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [module.vpc.default_security_group_id]
+  tags                = local.tags
   private_dns_enabled = true
 }

--- a/examples/interface-endpoint/outputs.tf
+++ b/examples/interface-endpoint/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}

--- a/examples/interface-endpoint/variables.tf
+++ b/examples/interface-endpoint/variables.tf
@@ -1,0 +1,9 @@
+variable "name_prefix" {
+  type    = string
+  default = "vpc-basic-example"
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-1"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,3 +36,7 @@ output "cidr_block" {
   value       = aws_vpc.main.cidr_block
 }
 
+output "default_security_group_id" {
+  description = "The id of the VPC default security group"
+  value       = aws_vpc.main.default_security_group_id
+}


### PR DESCRIPTION
* add contributions to licence
update README to include VPC Gateway endpoints
change interpolations to HCL2 expressions
add an example of adding an interface endpoint
add VPC endpoints for dynamodb and s3 to module
add default_security_grpoup_id to outputs so that it can be used to add interface endpoints outside the module

* Change example to use Endpoints necessary for SSM Session Manager - used to test this works